### PR TITLE
Fix grammar in warning about bare predicates

### DIFF
--- a/R/eval-walk.R
+++ b/R/eval-walk.R
@@ -422,7 +422,7 @@ eval_sym <- function(expr, data_mask, context_mask, strict = FALSE) {
     # Formally deprecated in 1.2.0
     lifecycle::deprecate_soft("1.1.0",
       what = I("Use of bare predicate functions"),
-      with = I("wrap predicates in `where()`"),
+      with = I("`where()` to wrap predicate functions"),
       details = c(
         " " = "# Was:",
         " " = glue("data %>% select({name})"),

--- a/tests/testthat/_snaps/eval-walk.md
+++ b/tests/testthat/_snaps/eval-walk.md
@@ -91,7 +91,7 @@
     Condition
       Warning:
       Use of bare predicate functions was deprecated in tidyselect 1.1.0.
-      i Please use wrap predicates in `where()` instead.
+      i Please use `where()` to wrap predicate functions instead.
         # Was:
         data %>% select(is_integer)
       
@@ -102,7 +102,7 @@
     Condition
       Warning:
       Use of bare predicate functions was deprecated in tidyselect 1.1.0.
-      i Please use wrap predicates in `where()` instead.
+      i Please use `where()` to wrap predicate functions instead.
         # Was:
         data %>% select(is.numeric)
       
@@ -113,7 +113,7 @@
     Condition
       Warning:
       Use of bare predicate functions was deprecated in tidyselect 1.1.0.
-      i Please use wrap predicates in `where()` instead.
+      i Please use `where()` to wrap predicate functions instead.
         # Was:
         data %>% select(isTRUE)
       
@@ -125,7 +125,7 @@
     Condition
       Warning:
       Use of bare predicate functions was deprecated in tidyselect 1.1.0.
-      i Please use wrap predicates in `where()` instead.
+      i Please use `where()` to wrap predicate functions instead.
         # Was:
         data %>% select(is_integer)
       


### PR DESCRIPTION
When a predicate function is used in `select()` to select columns for which a function returns `TRUE`, a warning appears, saying:
"Please use wrap predicates in `where()` instead.", which is grammatically incorrect.

To correct the warning's grammar, this commit changes the warning to say:
"Please use `where()` to wrap predicate functions instead."